### PR TITLE
ci: add GitHub Actions pipeline (lint + format + tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+# CI — runs on every push to main and every pull request.
+# Three gates must pass before code is considered green:
+#   1. ruff check   — lint (dead code, unused imports, bug-prone patterns)
+#   2. ruff format  — style is consistent (fails if any file isn't formatted)
+#   3. pytest       — the test suite passes
+name: CI
+
+# WHEN this runs. PRs get checked before merge; pushes to main re-verify
+# the integrated result. Limiting push to `main` avoids double-runs on
+# branches that already run via their PR.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# If you push twice quickly, cancel the older in-flight run for the same
+# branch/PR — saves CI minutes and gives you the latest result faster.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest  # Linux: onnxruntime/fastembed wheels resolve here
+    steps:
+      # Pulls the repo onto the runner so the steps below can see the code.
+      - uses: actions/checkout@v4
+
+      # Installs `uv` (our package manager) and caches the dependency
+      # download between runs so installs stay fast.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      # Creates the venv from uv.lock EXACTLY. `--locked` fails if the lock
+      # is stale vs pyproject.toml — so dependency drift can't sneak in.
+      # `--dev` includes the dev group (pytest, ruff).
+      - name: Install dependencies
+        run: uv sync --locked --dev
+
+      # Gate 1 — lint. `uv run` executes inside the project venv.
+      - name: Lint (ruff check)
+        run: uv run ruff check .
+
+      # Gate 2 — formatting. `--check` only reports; it never rewrites files
+      # in CI. Run `uv run ruff format .` locally to fix.
+      - name: Format check (ruff format)
+        run: uv run ruff format --check .
+
+      # Gate 3 — tests. conftest.py disables OTel, so no Phoenix needed.
+      - name: Tests (pytest)
+        run: uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,25 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
+    "ruff>=0.9.0",
 ]
+
+# --- Ruff: linter (check) + formatter (format) ---
+# One fast tool replacing flake8 + isort + black. Config lives here so local
+# runs and CI enforce identical rules.
+[tool.ruff]
+target-version = "py313"
+line-length = 88
+
+[tool.ruff.lint]
+# E = pycodestyle, F = pyflakes (dead code, unused imports). Ruff's defaults.
+[tool.ruff.lint.per-file-ignores]
+# Router imports sit after `app` is created to avoid circular imports.
+"src/app.py" = ["E402"]
+# Imports follow a sys.path tweak in this manual log-check script.
+"tests/test_logging.py" = ["E402"]
+
+# --- Pytest: where tests live + default flags ---
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/src/adapters/vector_store/qdrant.py
+++ b/src/adapters/vector_store/qdrant.py
@@ -1,19 +1,29 @@
 import logging
 from qdrant_client import AsyncQdrantClient
 from qdrant_client.http.models import (
-    Distance, VectorParams, SparseVectorParams, PointStruct, 
-    SparseVector, PayloadSchemaType, Prefetch, FusionQuery, Fusion,
-    Filter, FieldCondition, MatchValue
+    Distance,
+    VectorParams,
+    SparseVectorParams,
+    PointStruct,
+    SparseVector,
+    PayloadSchemaType,
+    Prefetch,
+    FusionQuery,
+    Fusion,
+    Filter,
+    FieldCondition,
+    MatchValue,
 )
 from src.core.config import get_settings
 from src.core.exceptions import (
     VectorStoreInitializationError,
-    VectorStoreOperationError
+    VectorStoreOperationError,
 )
 from src.observability.tracing import traced
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
 
 class QdrantManager:
     """
@@ -27,7 +37,7 @@ class QdrantManager:
             port=settings.qdrant_port,
             api_key=settings.qdrant_api_key,
             grpc_port=settings.qdrant_grpc_port,
-            prefer_grpc=False
+            prefer_grpc=False,
         )
         self.collection_name = settings.qdrant_collection_name
         self.dense_vector_name = "dense-text"
@@ -40,9 +50,11 @@ class QdrantManager:
         """
         try:
             exists = await self.client.collection_exists(self.collection_name)
-            
+
             if not exists:
-                logger.info(f"Creating collection '{self.collection_name}' with Hybrid Search config...")
+                logger.info(
+                    f"Creating collection '{self.collection_name}' with Hybrid Search config..."
+                )
                 await self.client.create_collection(
                     collection_name=self.collection_name,
                     vectors_config={
@@ -53,30 +65,41 @@ class QdrantManager:
                     },
                     sparse_vectors_config={
                         self.sparse_vector_name: SparseVectorParams()
-                    }
+                    },
                 )
                 logger.info(f"Collection '{self.collection_name}' created.")
             else:
-                logger.info(f"Validating existing collection '{self.collection_name}'...")
+                logger.info(
+                    f"Validating existing collection '{self.collection_name}'..."
+                )
                 info = await self.client.get_collection(self.collection_name)
                 params = info.config.params
-                
+
                 # Validation Logic
                 if not params.vectors or self.dense_vector_name not in params.vectors:
-                    raise ValueError(f"Missing dense vector config for '{self.dense_vector_name}'")
-                
+                    raise ValueError(
+                        f"Missing dense vector config for '{self.dense_vector_name}'"
+                    )
+
                 dense_cfg = params.vectors[self.dense_vector_name]
                 if dense_cfg.size != settings.qdrant_vector_size:
-                    raise ValueError(f"Vector size mismatch: expected {settings.qdrant_vector_size}, got {dense_cfg.size}")
+                    raise ValueError(
+                        f"Vector size mismatch: expected {settings.qdrant_vector_size}, got {dense_cfg.size}"
+                    )
 
-                if not params.sparse_vectors or self.sparse_vector_name not in params.sparse_vectors:
-                    raise ValueError(f"Missing sparse vector config for '{self.sparse_vector_name}'")
-                
+                if (
+                    not params.sparse_vectors
+                    or self.sparse_vector_name not in params.sparse_vectors
+                ):
+                    raise ValueError(
+                        f"Missing sparse vector config for '{self.sparse_vector_name}'"
+                    )
+
                 logger.info(f"Collection '{self.collection_name}' validated.")
 
             # Always ensure payload indexes for performance
             await self._ensure_payload_indexes()
-                
+
         except Exception as e:
             logger.error(f"Failed to initialize Qdrant: {str(e)}")
             raise VectorStoreInitializationError(details={"error": str(e)})
@@ -90,19 +113,26 @@ class QdrantManager:
             "document_id": PayloadSchemaType.KEYWORD,
             "created_at": PayloadSchemaType.DATETIME,
         }
-        
+
         for field, schema_type in indexed_fields.items():
             try:
                 await self.client.create_payload_index(
                     collection_name=self.collection_name,
                     field_name=field,
-                    field_schema=schema_type
+                    field_schema=schema_type,
                 )
             except Exception as e:
                 # Often occurs if index already exists, which is fine
                 logger.debug(f"Payload index for '{field}' skip/fail: {str(e)}")
 
-    async def upsert_document(self, doc_id: str, dense_vector: list[float], sparse_indices: list[int], sparse_values: list[float], payload: dict):
+    async def upsert_document(
+        self,
+        doc_id: str,
+        dense_vector: list[float],
+        sparse_indices: list[int],
+        sparse_values: list[float],
+        payload: dict,
+    ):
         """
         Standardized document insertion for Hybrid Search.
         """
@@ -154,7 +184,11 @@ class QdrantManager:
             message = str(e) or repr(e) or type(e).__name__
             raise VectorStoreOperationError(
                 operation="upsert",
-                details={"error": message, "point_count": len(points), "batch_size": batch_size},
+                details={
+                    "error": message,
+                    "point_count": len(points),
+                    "batch_size": batch_size,
+                },
             ) from e
 
     @traced("qdrant.hybrid_search")
@@ -189,7 +223,9 @@ class QdrantManager:
                         limit=limit,
                     ),
                     Prefetch(
-                        query=SparseVector(indices=sparse_indices, values=sparse_values),
+                        query=SparseVector(
+                            indices=sparse_indices, values=sparse_values
+                        ),
                         using=self.sparse_vector_name,
                         limit=limit,
                     ),
@@ -202,7 +238,9 @@ class QdrantManager:
             )
             return response.points
         except Exception as e:
-            raise VectorStoreOperationError(operation="hybrid_search", details={"error": str(e)})
+            raise VectorStoreOperationError(
+                operation="hybrid_search", details={"error": str(e)}
+            )
 
     async def hybrid_search(
         self,
@@ -242,7 +280,9 @@ class QdrantManager:
                 ),
             )
         except Exception as e:
-            raise VectorStoreOperationError(operation="delete_by_document_id", details={"error": str(e)})
+            raise VectorStoreOperationError(
+                operation="delete_by_document_id", details={"error": str(e)}
+            )
 
     async def list_documents_by_tenant(self, *, tenant_id: str) -> list[dict]:
         """
@@ -291,7 +331,9 @@ class QdrantManager:
                     summary["chunk_count"] += 1
 
                     created_at = payload.get("created_at", "")
-                    if created_at and (not summary["created_at"] or created_at < summary["created_at"]):
+                    if created_at and (
+                        not summary["created_at"] or created_at < summary["created_at"]
+                    ):
                         summary["created_at"] = created_at
 
                 if offset is None:
@@ -299,11 +341,17 @@ class QdrantManager:
 
             return sorted(
                 documents.values(),
-                key=lambda document: (document["created_at"], document["source_name"], document["document_id"]),
+                key=lambda document: (
+                    document["created_at"],
+                    document["source_name"],
+                    document["document_id"],
+                ),
                 reverse=True,
             )
         except Exception as e:
-            raise VectorStoreOperationError(operation="list_documents_by_tenant", details={"error": str(e)})
+            raise VectorStoreOperationError(
+                operation="list_documents_by_tenant", details={"error": str(e)}
+            )
 
     async def health_check(self) -> dict:
         """
@@ -313,26 +361,24 @@ class QdrantManager:
             # Check basic connection
             # We use a simple lightweight check
             collections = await self.client.get_collections()
-            
+
             # Check target collection
             exists = await self.client.collection_exists(self.collection_name)
-            
+
             return {
                 "status": "healthy" if exists else "degraded",
                 "connection": "ok",
                 "collection_found": exists,
                 "collection_name": self.collection_name,
-                "total_collections": len(collections.collections)
+                "total_collections": len(collections.collections),
             }
         except Exception as e:
-            return {
-                "status": "unhealthy",
-                "error": str(e)
-            }
+            return {"status": "unhealthy", "error": str(e)}
 
     async def close(self):
         """Closes the client connection."""
         await self.client.close()
+
 
 # Singleton instance for easy access across the app
 qdrant_manager = QdrantManager()

--- a/src/agents/sql_agent.py
+++ b/src/agents/sql_agent.py
@@ -88,7 +88,9 @@ class HuggingFaceBackend:
     def model_name(self) -> str:
         return self._model
 
-    async def chat(self, messages: list[dict], tools: list[dict]) -> tuple[dict, list[dict]]:
+    async def chat(
+        self, messages: list[dict], tools: list[dict]
+    ) -> tuple[dict, list[dict]]:
         response = await self._client.chat_completion(
             messages=messages,
             tools=tools,
@@ -114,7 +116,11 @@ class HuggingFaceBackend:
                     },
                 }
             )
-        assistant = {"role": "assistant", "content": message.content or "", "tool_calls": tool_calls_payload}
+        assistant = {
+            "role": "assistant",
+            "content": message.content or "",
+            "tool_calls": tool_calls_payload,
+        }
         return assistant, calls
 
     @staticmethod
@@ -135,11 +141,19 @@ class OllamaBackend:
     def model_name(self) -> str:
         return self._model
 
-    async def chat(self, messages: list[dict], tools: list[dict]) -> tuple[dict, list[dict]]:
-        response = await self._client.chat(model=self._model, messages=messages, tools=tools)
+    async def chat(
+        self, messages: list[dict], tools: list[dict]
+    ) -> tuple[dict, list[dict]]:
+        response = await self._client.chat(
+            model=self._model, messages=messages, tools=tools
+        )
         message = response.message
         calls = [
-            {"id": None, "name": tc.function.name, "args": _parse_args(tc.function.arguments)}
+            {
+                "id": None,
+                "name": tc.function.name,
+                "args": _parse_args(tc.function.arguments),
+            }
             for tc in (message.tool_calls or [])
         ]
         assistant = {
@@ -215,7 +229,9 @@ async def run_agent(question: str) -> dict:
                     return {"answer": answer, "steps": steps}
 
                 for call in calls:
-                    with _tracer.start_as_current_span(f"tool.{call['name']}") as tool_span:
+                    with _tracer.start_as_current_span(
+                        f"tool.{call['name']}"
+                    ) as tool_span:
                         tool_span.set_attribute("openinference.span.kind", "TOOL")
                         tool_span.set_attribute("tool.name", call["name"])
                         tool_span.set_attribute(
@@ -225,11 +241,15 @@ async def run_agent(question: str) -> dict:
                         # A tool result can be several content parts (e.g.
                         # list_tables returns one per table) — join them all.
                         text = "\n".join(
-                            part.text for part in (result.content or []) if hasattr(part, "text")
+                            part.text
+                            for part in (result.content or [])
+                            if hasattr(part, "text")
                         )
                         tool_span.set_attribute("output.value", text[:1000])
 
-                    steps.append({"tool": call["name"], "args": call["args"], "result": text})
+                    steps.append(
+                        {"tool": call["name"], "args": call["args"], "result": text}
+                    )
                     messages.append(backend.tool_message(call, text))
 
             agent_span.set_attribute("output.value", "(max steps)")

--- a/src/api/routers/agent.py
+++ b/src/api/routers/agent.py
@@ -15,7 +15,9 @@ router = APIRouter(prefix="/agent", tags=["Agent"])
 
 
 class AgentAskRequest(BaseModel):
-    question: str = Field(..., min_length=1, examples=["En çok ciro yapan 3 ürün hangisi?"])
+    question: str = Field(
+        ..., min_length=1, examples=["En çok ciro yapan 3 ürün hangisi?"]
+    )
 
 
 class AgentStep(BaseModel):

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -83,7 +83,13 @@ class ResourceNotFoundError(AppException):
 
 
 class VectorStoreError(AppException):
-    def __init__(self, message: str, code: str = "VEC_00", status_code: int = 500, details: Optional[Any] = None):
+    def __init__(
+        self,
+        message: str,
+        code: str = "VEC_00",
+        status_code: int = 500,
+        details: Optional[Any] = None,
+    ):
         super().__init__(
             code=code,
             message=message,

--- a/src/mcp_server/dev_client.py
+++ b/src/mcp_server/dev_client.py
@@ -54,7 +54,9 @@ async def main() -> None:
 
             # 6) Trigger the file guard on purpose.
             print("=== call read_logs(filename='../pyproject.toml') -> guard ===")
-            res = await session.call_tool("read_logs", {"filename": "../pyproject.toml"})
+            res = await session.call_tool(
+                "read_logs", {"filename": "../pyproject.toml"}
+            )
             print("isError =", res.isError)
             print(res.content[0].text)
 

--- a/src/mcp_server/guards.py
+++ b/src/mcp_server/guards.py
@@ -20,10 +20,34 @@ from src.core.exceptions import SqlGuardError
 # data-modifying CTE (``WITH x AS (DELETE ...)``) is caught too.
 _FORBIDDEN_KEYWORDS = frozenset(
     {
-        "insert", "update", "delete", "truncate", "drop", "alter", "create",
-        "grant", "revoke", "merge", "call", "do", "copy", "vacuum", "analyze",
-        "reindex", "cluster", "comment", "lock", "set", "reset", "begin",
-        "commit", "rollback", "savepoint", "prepare", "execute", "explain",
+        "insert",
+        "update",
+        "delete",
+        "truncate",
+        "drop",
+        "alter",
+        "create",
+        "grant",
+        "revoke",
+        "merge",
+        "call",
+        "do",
+        "copy",
+        "vacuum",
+        "analyze",
+        "reindex",
+        "cluster",
+        "comment",
+        "lock",
+        "set",
+        "reset",
+        "begin",
+        "commit",
+        "rollback",
+        "savepoint",
+        "prepare",
+        "execute",
+        "explain",
     }
 )
 

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -10,7 +10,6 @@ Run over stdio (how an agent client launches it):
     uv run python -m src.mcp_server.server
 """
 
-import json
 import logging
 
 from mcp.server.fastmcp import FastMCP

--- a/src/mcp_server/tools/rag_search.py
+++ b/src/mcp_server/tools/rag_search.py
@@ -15,7 +15,9 @@ def register(mcp: FastMCP) -> None:
     retriever = HybridRetriever()
 
     @mcp.tool()
-    async def rag_search(query: str, tenant_id: str, top_k: int = 5) -> list[MCPSearchResult]:
+    async def rag_search(
+        query: str, tenant_id: str, top_k: int = 5
+    ) -> list[MCPSearchResult]:
         """Search the knowledge base using hybrid dense+sparse retrieval with reranking.
 
         Use this tool to retrieve relevant document chunks for a given question or topic.
@@ -29,7 +31,9 @@ def register(mcp: FastMCP) -> None:
         top_k = max(1, min(top_k, 20))
 
         try:
-            chunks = await retriever.search(query=query, tenant_id=tenant_id, top_k=top_k)
+            chunks = await retriever.search(
+                query=query, tenant_id=tenant_id, top_k=top_k
+            )
         except RagRetrievalError as exc:
             logger.error("rag_search failed: %s", exc)
             raise

--- a/src/mcp_server/tools/read_logs.py
+++ b/src/mcp_server/tools/read_logs.py
@@ -34,7 +34,9 @@ def register(mcp: FastMCP) -> None:
             missing.
         """
         if "/" in filename or "\\" in filename or filename.startswith("."):
-            raise ValueError("filename must be a plain file name inside the logs directory")
+            raise ValueError(
+                "filename must be a plain file name inside the logs directory"
+            )
 
         lines = max(1, min(lines, _MAX_LINES))
 

--- a/src/observability/logging.py
+++ b/src/observability/logging.py
@@ -13,6 +13,7 @@ from src.core.config import get_settings
 
 class QueueHandlerInit:
     """Ensures that the QueueListener for the QueueHandler is started exactly once, even in reload/multi-import scenarios."""
+
     _started = False
 
     def __init__(self, handler_name: str = "queue_handler") -> None:
@@ -52,11 +53,12 @@ class CustomQueueHandler(logging.handlers.QueueHandler):
 
 class CustomJSONFormatter(logging.Formatter):
     """Custom JSON formatter that converts log records into structured JSON format."""
+
     def __init__(
-            self,
-            *,
-            fmt_keys: dict[str, str] | None = None,
-            builtin_attrs: list[str] | None = None,
+        self,
+        *,
+        fmt_keys: dict[str, str] | None = None,
+        builtin_attrs: list[str] | None = None,
     ):
         super().__init__()
         self.fmt_keys = fmt_keys if fmt_keys is not None else {}
@@ -66,11 +68,13 @@ class CustomJSONFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         message = self._prepare_log_dict(record)
         return json.dumps(message, default=str)
-    
+
     def _prepare_log_dict(self, record: logging.LogRecord) -> dict:
         always_fields = {
             "message": record.getMessage(),
-            "timestamp": dt.datetime.fromtimestamp(record.created, tz=dt.timezone.utc).isoformat(),
+            "timestamp": dt.datetime.fromtimestamp(
+                record.created, tz=dt.timezone.utc
+            ).isoformat(),
         }
         if record.exc_info is not None:
             always_fields["exc_info"] = self.formatException(record.exc_info)
@@ -95,6 +99,7 @@ class CustomJSONFormatter(logging.Formatter):
 
 class NonErrorFilter(logging.Filter):
     """Logging filter that allows only log records with level INFO or below (DEBUG, INFO) to pass through."""
+
     @override
     def filter(self, record: logging.LogRecord) -> bool | logging.LogRecord:
         # Only allow log records with level INFO or below (DEBUG, INFO) to pass through this filter
@@ -109,7 +114,7 @@ def _resolve_log_level(level_name: str) -> str:
 
 def setup_logging() -> None:
     """Initialize logging with dynamic terminal levels and persistent file logging.
-    
+
     Features:
     - Terminal handler levels controlled by Settings.log_level (dynamic).
     - File log handler follows log_level dynamically. Useful for checking what your LOG_LEVEL actually captures.
@@ -117,10 +122,10 @@ def setup_logging() -> None:
     - Hierarchical loggers: src.api, src.core, src.adapters, src.rag etc. can be configured independently.
     - Non-blocking I/O via QueueHandler + QueueListener.
     - stdout/stderr separation: INFO and below go to stdout, WARNING+ to stderr.
-    
+
     Logger hierarchy example:
         logger = logging.getLogger(__name__)  # Gets "src.api", "src.adapters", etc.
-        
+
     Configure per-module levels in logging_config.json if needed.
     """
 

--- a/src/observability/tracing.py
+++ b/src/observability/tracing.py
@@ -20,11 +20,13 @@ def setup_tracing() -> None:
         logger.info("OpenTelemetry tracing is disabled.")
         return
 
-    resource = Resource.create({
-        "service.name": settings.otel_service_name,
-        "service.version": settings.version,
-        "deployment.environment": settings.environment,
-    })
+    resource = Resource.create(
+        {
+            "service.name": settings.otel_service_name,
+            "service.version": settings.version,
+            "deployment.environment": settings.environment,
+        }
+    )
     provider = TracerProvider(resource=resource)
     exporter = OTLPSpanExporter(
         endpoint=f"{settings.otel_exporter_otlp_endpoint}/v1/traces",
@@ -43,6 +45,7 @@ def get_tracer(name: str) -> trace.Tracer:
 
 def traced(span_name: str, span_kind: str | None = None):
     """Wraps an async or sync method in a span. Errors are recorded automatically."""
+
     def decorator(fn):
         tracer = get_tracer(fn.__module__)
 
@@ -75,4 +78,5 @@ def traced(span_name: str, span_kind: str | None = None):
                     raise
 
         return async_wrapper if asyncio.iscoroutinefunction(fn) else sync_wrapper
+
     return decorator

--- a/src/rag/chunking.py
+++ b/src/rag/chunking.py
@@ -29,7 +29,9 @@ class HeadingAwareChunker:
         if max_tokens < 20:
             raise ValueError("max_tokens must be at least 20")
         if overlap_tokens < 0 or overlap_tokens >= max_tokens:
-            raise ValueError("overlap_tokens must be non-negative and smaller than max_tokens")
+            raise ValueError(
+                "overlap_tokens must be non-negative and smaller than max_tokens"
+            )
 
         self.max_tokens = max_tokens
         self.overlap_tokens = overlap_tokens
@@ -231,7 +233,9 @@ class TableChunker:
         named = [header for header in headers if header]
         return f"columns: {', '.join(named)}" if named else ""
 
-    def _emit(self, schema_prefix: str, records: list[str], chunk_index: int) -> ChunkDraft:
+    def _emit(
+        self, schema_prefix: str, records: list[str], chunk_index: int
+    ) -> ChunkDraft:
         body = "\n".join(records)
         text = f"{schema_prefix}\n{body}" if schema_prefix else body
         return ChunkDraft(

--- a/src/rag/embeddings.py
+++ b/src/rag/embeddings.py
@@ -50,8 +50,13 @@ class FastEmbedProvider:
         span.set_attribute("embedding.model_name", self.dense_model_name)
         try:
             self._validate_texts(texts)
-            dense_vectors = [self._as_float_list(vector) for vector in self.dense_model.embed(texts)]
-            sparse_vectors = [self._to_sparse_embedding(vector) for vector in self.sparse_model.embed(texts)]
+            dense_vectors = [
+                self._as_float_list(vector) for vector in self.dense_model.embed(texts)
+            ]
+            sparse_vectors = [
+                self._to_sparse_embedding(vector)
+                for vector in self.sparse_model.embed(texts)
+            ]
             self._validate_embedding_counts(
                 expected_count=len(texts),
                 dense_count=len(dense_vectors),
@@ -97,7 +102,9 @@ class FastEmbedProvider:
             try:
                 from fastembed import SparseTextEmbedding
 
-                self._sparse_model = SparseTextEmbedding(model_name=self.sparse_model_name)
+                self._sparse_model = SparseTextEmbedding(
+                    model_name=self.sparse_model_name
+                )
             except Exception as exc:
                 raise RagEmbeddingError(
                     details={"model": self.sparse_model_name, "error": str(exc)}
@@ -128,7 +135,10 @@ class FastEmbedProvider:
         for index, text in enumerate(texts):
             if not text.strip():
                 raise RagEmbeddingError(
-                    details={"error": "embedding input text must not be blank", "index": index}
+                    details={
+                        "error": "embedding input text must not be blank",
+                        "index": index,
+                    }
                 )
 
     @staticmethod

--- a/src/rag/ingest.py
+++ b/src/rag/ingest.py
@@ -94,7 +94,9 @@ class DocumentIngestService:
 
             records = []
             for chunk, embedding in zip(chunks, embeddings):
-                chunk_id = self._stable_uuid(f"{document_id}:{content_hash}:{chunk.chunk_index}")
+                chunk_id = self._stable_uuid(
+                    f"{document_id}:{content_hash}:{chunk.chunk_index}"
+                )
                 stored_chunk = Chunk(
                     chunk_id=chunk_id,
                     document_id=document.document_id,
@@ -146,7 +148,11 @@ class DocumentIngestService:
             raise
         except Exception as exc:
             raise RagIngestError(
-                details={"source_name": source_name, "tenant_id": tenant_id, "error": str(exc)}
+                details={
+                    "source_name": source_name,
+                    "tenant_id": tenant_id,
+                    "error": str(exc),
+                }
             ) from exc
 
     async def list_documents(self, *, tenant_id: str, limit: int = 100) -> dict:
@@ -156,7 +162,9 @@ class DocumentIngestService:
             raise RagValidationError("limit must be greater than 0")
 
         try:
-            documents = await self.vector_store.list_documents_by_tenant(tenant_id=tenant_id)
+            documents = await self.vector_store.list_documents_by_tenant(
+                tenant_id=tenant_id
+            )
             limited_documents = documents[:limit]
             return {
                 "documents": limited_documents,
@@ -165,7 +173,9 @@ class DocumentIngestService:
         except AppException:
             raise
         except Exception as exc:
-            raise DocumentListError(details={"tenant_id": tenant_id, "error": str(exc)}) from exc
+            raise DocumentListError(
+                details={"tenant_id": tenant_id, "error": str(exc)}
+            ) from exc
 
     async def delete_document(self, *, document_id: str, tenant_id: str) -> dict:
         if not document_id.strip():
@@ -187,7 +197,11 @@ class DocumentIngestService:
             raise
         except Exception as exc:
             raise DocumentDeleteError(
-                details={"document_id": document_id, "tenant_id": tenant_id, "error": str(exc)}
+                details={
+                    "document_id": document_id,
+                    "tenant_id": tenant_id,
+                    "error": str(exc),
+                }
             ) from exc
 
     @staticmethod

--- a/src/rag/retriever.py
+++ b/src/rag/retriever.py
@@ -51,7 +51,9 @@ class HybridRetriever:
         span.set_attribute("rag.rerank_enabled", self.reranker is not None)
 
         try:
-            embedding = await run_in_threadpool(self.embedding_provider.embed_query, query)
+            embedding = await run_in_threadpool(
+                self.embedding_provider.embed_query, query
+            )
             raw_results = await self.vector_store.query_hybrid(
                 dense_vector=embedding.dense,
                 sparse_indices=embedding.sparse.indices,
@@ -65,7 +67,9 @@ class HybridRetriever:
 
             for i, r in enumerate(results):
                 span.set_attribute(f"retrieval.documents.{i}.document.id", r.chunk_id)
-                span.set_attribute(f"retrieval.documents.{i}.document.content", r.text[:500])
+                span.set_attribute(
+                    f"retrieval.documents.{i}.document.content", r.text[:500]
+                )
                 span.set_attribute(f"retrieval.documents.{i}.document.score", r.score)
             span.set_attribute("rag.candidates", len(raw_results))
             span.set_attribute("rag.result_count", len(results))
@@ -78,7 +82,9 @@ class HybridRetriever:
             ) from exc
 
     @traced("rag.rerank", span_kind="RERANKER")
-    def _rerank(self, query: str, candidates: list[RetrievedChunk]) -> list[RetrievedChunk]:
+    def _rerank(
+        self, query: str, candidates: list[RetrievedChunk]
+    ) -> list[RetrievedChunk]:
         """Re-score candidates with the cross-encoder, then order best-first.
 
         Without a reranker we fall back to the hybrid retrieval score. With one,
@@ -128,7 +134,8 @@ class HybridRetriever:
         metadata = {
             key: value
             for key, value in payload.items()
-            if key not in {"chunk_id", "document_id", "source_name", "heading_path", "text"}
+            if key
+            not in {"chunk_id", "document_id", "source_name", "heading_path", "text"}
         }
 
         return RetrievedChunk(

--- a/tests/api/test_documents_upload.py
+++ b/tests/api/test_documents_upload.py
@@ -11,7 +11,9 @@ class _FakeDocumentIngestService:
     def __init__(self) -> None:
         self.calls = []
 
-    async def ingest_document(self, *, source_name: str, content: str, tenant_id: str, content_kind: str):
+    async def ingest_document(
+        self, *, source_name: str, content: str, tenant_id: str, content_kind: str
+    ):
         self.calls.append(
             {
                 "source_name": source_name,

--- a/tests/mcp/test_rag_search.py
+++ b/tests/mcp/test_rag_search.py
@@ -85,7 +85,9 @@ def test_rag_search_clamps_top_k(monkeypatch, requested, expected):
     mcp, fake = _register_with(monkeypatch, [])
 
     asyncio.run(
-        mcp.call_tool("rag_search", {"query": "q", "tenant_id": "t1", "top_k": requested})
+        mcp.call_tool(
+            "rag_search", {"query": "q", "tenant_id": "t1", "top_k": requested}
+        )
     )
 
     assert fake.calls[0]["top_k"] == expected

--- a/tests/mcp/test_sql_tools.py
+++ b/tests/mcp/test_sql_tools.py
@@ -57,7 +57,9 @@ def test_sql_query_returns_json_rows(monkeypatch):
     )
     mcp = _build_mcp()
 
-    out = _text(asyncio.run(mcp.call_tool("sql_query", {"sql": "SELECT name FROM products"})))
+    out = _text(
+        asyncio.run(mcp.call_tool("sql_query", {"sql": "SELECT name FROM products"}))
+    )
 
     assert "Wireless Mouse" in out
     assert "174.93" in out
@@ -67,7 +69,9 @@ def test_sql_query_empty_result(monkeypatch):
     monkeypatch.setattr(sql.postgres_manager, "run_select", _fake_select([]))
     mcp = _build_mcp()
 
-    out = _text(asyncio.run(mcp.call_tool("sql_query", {"sql": "SELECT 1 WHERE false"})))
+    out = _text(
+        asyncio.run(mcp.call_tool("sql_query", {"sql": "SELECT 1 WHERE false"}))
+    )
 
     assert "no rows" in out.lower()
 

--- a/tests/rag/test_loaders.py
+++ b/tests/rag/test_loaders.py
@@ -60,7 +60,12 @@ def test_load_document_rejects_unsupported_extensions():
         load_document(source_name="data.xlsx", raw_content=b"content")
 
     assert exc_info.value.code == "RAG_422"
-    assert exc_info.value.details["supported_extensions"] == [".csv", ".md", ".pdf", ".txt"]
+    assert exc_info.value.details["supported_extensions"] == [
+        ".csv",
+        ".md",
+        ".pdf",
+        ".txt",
+    ]
 
 
 def test_load_document_rejects_non_utf8_content():

--- a/tests/rag/test_table_chunker.py
+++ b/tests/rag/test_table_chunker.py
@@ -26,9 +26,7 @@ def test_every_chunk_repeats_the_column_schema():
 def test_token_budget_packs_whole_rows_without_splitting_records():
     chunker = TableChunker(max_tokens=25)
 
-    chunks = chunker.split(
-        "name,role\nAyse,admin\nMehmet,viewer\nFatma,editor\n"
-    )
+    chunks = chunker.split("name,role\nAyse,admin\nMehmet,viewer\nFatma,editor\n")
 
     # Records are atomic: a row never appears split across two chunks.
     assert len(chunks) > 1

--- a/tests/test_rag_foundation.py
+++ b/tests/test_rag_foundation.py
@@ -156,7 +156,9 @@ def test_plain_text_chunks_predictably_without_headings() -> None:
 def test_heading_aware_chunking_respects_token_budget_with_heading_context() -> None:
     chunker = HeadingAwareChunker(max_tokens=25, overlap_tokens=5)
 
-    chunks = chunker.split("# Policy\n## Access\n" + ("alpha beta gamma delta epsilon. " * 12))
+    chunks = chunker.split(
+        "# Policy\n## Access\n" + ("alpha beta gamma delta epsilon. " * 12)
+    )
 
     assert len(chunks) > 1
     assert all(chunk.heading_path == ["Policy", "Access"] for chunk in chunks)
@@ -231,10 +233,18 @@ def test_ingest_service_deletes_document_by_tenant_boundary() -> None:
         chunker=HeadingAwareChunker(max_tokens=60, overlap_tokens=5),
     )
 
-    result = asyncio.run(service.delete_document(document_id="doc-1", tenant_id="default"))
+    result = asyncio.run(
+        service.delete_document(document_id="doc-1", tenant_id="default")
+    )
 
-    assert result == {"document_id": "doc-1", "tenant_id": "default", "status": "deleted"}
-    assert vector_store.deleted_documents == [{"document_id": "doc-1", "tenant_id": "default"}]
+    assert result == {
+        "document_id": "doc-1",
+        "tenant_id": "default",
+        "status": "deleted",
+    }
+    assert vector_store.deleted_documents == [
+        {"document_id": "doc-1", "tenant_id": "default"}
+    ]
 
 
 def test_ingest_service_lists_documents_with_limit() -> None:
@@ -260,7 +270,9 @@ def test_retriever_calls_hybrid_search_and_maps_results() -> None:
         reranker=FakeReranker(),
     )
 
-    results = asyncio.run(retriever.search(query="access policy", tenant_id="default", top_k=1))
+    results = asyncio.run(
+        retriever.search(query="access policy", tenant_id="default", top_k=1)
+    )
 
     assert vector_store.search_calls[0]["dense_vector"] == [0.5, 0.1, 0.2]
     assert vector_store.search_calls[0]["sparse_indices"] == [7]
@@ -282,7 +294,9 @@ def test_retriever_preserves_app_exceptions() -> None:
     )
 
     try:
-        asyncio.run(retriever.search(query="access policy", tenant_id="default", top_k=1))
+        asyncio.run(
+            retriever.search(query="access policy", tenant_id="default", top_k=1)
+        )
     except RagEmbeddingError as exc:
         assert exc.code == "RAG_EMBED_500"
     else:
@@ -294,9 +308,18 @@ def test_retriever_reranks_candidates_before_top_k() -> None:
         async def query_hybrid(self, **kwargs):
             _ = kwargs
             return [
-                {"score": 0.9, "payload": {"chunk_id": "a", "document_id": "d", "text": "alpha"}},
-                {"score": 0.5, "payload": {"chunk_id": "b", "document_id": "d", "text": "beta"}},
-                {"score": 0.7, "payload": {"chunk_id": "c", "document_id": "d", "text": "gamma"}},
+                {
+                    "score": 0.9,
+                    "payload": {"chunk_id": "a", "document_id": "d", "text": "alpha"},
+                },
+                {
+                    "score": 0.5,
+                    "payload": {"chunk_id": "b", "document_id": "d", "text": "beta"},
+                },
+                {
+                    "score": 0.7,
+                    "payload": {"chunk_id": "c", "document_id": "d", "text": "gamma"},
+                },
             ]
 
     # Reranker promotes 'b' (the lowest retrieval score) to the top.
@@ -339,7 +362,9 @@ def test_retriever_top_k_sorting_is_deterministic() -> None:
         RetrievedChunk("c", "doc-3", "c.md", [], "third", 0.1),
     ]
 
-    sorted_results = sorted(results, key=lambda item: (-item.score, item.document_id, item.chunk_id))[:2]
+    sorted_results = sorted(
+        results, key=lambda item: (-item.score, item.document_id, item.chunk_id)
+    )[:2]
 
     assert [result.chunk_id for result in sorted_results] == ["a", "b"]
 
@@ -350,18 +375,28 @@ def test_ingest_endpoint_returns_ingest_result(monkeypatch) -> None:
             assert kwargs["tenant_id"] == "default"
             return {"document_id": "doc-1", "chunk_count": 2, "status": "ingested"}
 
-    monkeypatch.setattr(documents_router, "document_ingest_service", FakeIngestService())
+    monkeypatch.setattr(
+        documents_router, "document_ingest_service", FakeIngestService()
+    )
 
     client = TestClient(app, raise_server_exceptions=False)
     response = client.post(
         "/documents/ingest",
-        json={"source_name": "policy.md", "content": "# Policy\nText", "tenant_id": "default"},
+        json={
+            "source_name": "policy.md",
+            "content": "# Policy\nText",
+            "tenant_id": "default",
+        },
     )
 
     assert response.status_code == 200
     body = response.json()
     assert body["success"] is True
-    assert body["data"] == {"document_id": "doc-1", "chunk_count": 2, "status": "ingested"}
+    assert body["data"] == {
+        "document_id": "doc-1",
+        "chunk_count": 2,
+        "status": "ingested",
+    }
     assert body["request_id"]
 
 
@@ -383,7 +418,9 @@ def test_list_documents_endpoint_returns_document_summaries(monkeypatch) -> None
                 "count": 1,
             }
 
-    monkeypatch.setattr(documents_router, "document_ingest_service", FakeIngestService())
+    monkeypatch.setattr(
+        documents_router, "document_ingest_service", FakeIngestService()
+    )
 
     client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/documents", params={"tenant_id": "default", "limit": 10})
@@ -402,7 +439,9 @@ def test_delete_document_endpoint_returns_delete_result(monkeypatch) -> None:
             assert kwargs == {"document_id": "doc-1", "tenant_id": "default"}
             return {"document_id": "doc-1", "tenant_id": "default", "status": "deleted"}
 
-    monkeypatch.setattr(documents_router, "document_ingest_service", FakeIngestService())
+    monkeypatch.setattr(
+        documents_router, "document_ingest_service", FakeIngestService()
+    )
 
     client = TestClient(app, raise_server_exceptions=False)
     response = client.delete("/documents/doc-1", params={"tenant_id": "default"})
@@ -410,7 +449,11 @@ def test_delete_document_endpoint_returns_delete_result(monkeypatch) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["success"] is True
-    assert body["data"] == {"document_id": "doc-1", "tenant_id": "default", "status": "deleted"}
+    assert body["data"] == {
+        "document_id": "doc-1",
+        "tenant_id": "default",
+        "status": "deleted",
+    }
     assert body["request_id"]
 
 
@@ -433,7 +476,9 @@ def test_search_endpoint_returns_normalized_results(monkeypatch) -> None:
     monkeypatch.setattr(search_router, "hybrid_retriever", FakeRetriever())
 
     client = TestClient(app, raise_server_exceptions=False)
-    response = client.post("/search", json={"query": "access", "tenant_id": "default", "top_k": 1})
+    response = client.post(
+        "/search", json={"query": "access", "tenant_id": "default", "top_k": 1}
+    )
 
     assert response.status_code == 200
     body = response.json()

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -63,7 +64,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.9.0" },
+]
 
 [[package]]
 name = "altair"
@@ -1833,6 +1837,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add .github/workflows/ci.yml running three gates on every push to main and every PR: ruff check (lint), ruff format --check (style), and pytest.

- Configure ruff and pytest in pyproject.toml; add ruff to the dev group (uv.lock updated) so local and CI enforce identical rules.
- Remove a dead `json` import in mcp_server/server.py.
- Apply `ruff format` across the repo (style-only, no behavior change) so the format gate starts green.

E402 is per-file-ignored where imports intentionally follow setup code (src/app.py router imports, tests/test_logging.py sys.path tweak).